### PR TITLE
Fix permission error for "Auto LGTM CI/CD"

### DIFF
--- a/.github/workflows/LGTM.yml
+++ b/.github/workflows/LGTM.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   looks_good_to_me_for_owner:
-    permissions: write-all
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: LGTM Comment
@@ -15,4 +16,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pullRequestOpenedReactions: "hooray, +1"
-          pullRequestOpenedComment: LGTM
+          pullRequestOpenedComment: LGTM 👍


### PR DESCRIPTION
권한 문제 때문에 작동하지 않았던 CI/CD를 수정했습니다. 이제 PR이 생성되면 자동으로 `github-actions[bot]`이 "LGTM"을 날려줍니다

Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
- #29